### PR TITLE
feat(sh.meta_main): split sh.meta into sh.meta and sh.meta_main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 **/result
 **/repl-result-out
 **/.nvim.lua
+**/.cache
+**/compile_commands.json
+**/build

--- a/REPR.md
+++ b/REPR.md
@@ -149,6 +149,11 @@ Prior to 5.2 the io.popen command does not return exit code or signal. You can d
 	---each string in this table must begin with '__' or it will be ignored
 	---@field extra_cmd_results string[]|fun(opts: Shelua.Opts): string[]
 	extra_cmd_results = {},
+	---a list of functions to run in order on the command before running it.
+	---each one recieves the previous value and returns a new one.
+	---they are ran after concat_cmd or single_stdin and before the post_5_2_run and pre_5_2_run functions
+	---@field transforms? (fun(cmd: string|any): string|any)[]
+	transforms = {},
 ```
 
 And the final method, `concat_cmd`. This is the counterpart to `single_stdin`.

--- a/example.lua
+++ b/example.lua
@@ -40,17 +40,18 @@ print(sh.echo 'Hello World' :sed "s/Hello World/Goodbye Universe/g")
 sh.escape_args = false
 
 -- cloning sh with new settings, and "proper_pipes" setting (and others)
-local nsh = sh({
-  proper_pipes = true,
-  escape_args = true,
-  assert_zero = true,
-  transforms = {
+local nsh = sh(function (opts)
+  opts.proper_pipes = true
+  opts.escape_args = true
+  opts.assert_zero = true
+  opts.repr[opts.shell or "posix"].transforms = {
     function(cmd)
       print(cmd)
       return cmd
     end
   }
-})
+  return opts
+end)
 print(nsh.echo 'Hello world' :sed "s/Hello/Goodbye/g")
 print(nsh.sed(nsh.echo 'Hello world', nsh.echo 'Hello world', "s/Hello/Goodbye/g"))
 print(nsh.echo 'Hello World' :sed(nsh.echo 'Hello World', nsh.echo 'Hello World' :sed(nsh.echo 'Hello World', "s/Hello/Goodbye/g"), "s/World/Universe/g"))

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , n2l ? import (builtins.fetchGit (let
-    lock = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.n2l.locked;
+    lock = (builtins.fromJSON (builtins.readFile ../flake.lock)).nodes.n2l.locked;
   in {
     url = "https://github.com/${lock.owner}/${lock.repo}.git";
     rev = lock.rev;
@@ -25,9 +25,12 @@ in {
     TEMPDIR=$(mktemp -d)
     mkdir -p "$TEMPDIR"
     declare -f > "$LUA_SHELL_HOOKS"
+    envlib="$(realpath ./env.so)"
+    $CC -O2 -fPIC -shared -o "$envlib" "${./env.c}" -I"$(dirname $luaInterpreter)/../include"
     echo "_G.temp = '$TEMPDIR'
     _G.out = '${placeholder "out"}'
-    package.preload.sh = function() return dofile('${./lua/sh.lua}') end
+    os.env = package.loadlib('$envlib', 'luaopen_env')()
+    package.preload.sh = function() return dofile('${../lua/sh.lua}') end
     local ok, val = pcall(dofile, '${./nix.lua}')
     assert(ok, val)
     ok, val = pcall(val, '$LUA_SHELL_HOOKS')

--- a/nix/env.c
+++ b/nix/env.c
@@ -1,0 +1,54 @@
+#include <stdlib.h>
+#include <lua.h>
+#include <lauxlib.h>
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+static int env__newindex(lua_State *L) {
+    const char *key = luaL_checkstring(L, 2);
+#ifdef _WIN32
+    if (lua_isnil(L, 3)) {
+        if (SetEnvironmentVariable(key, NULL) == 0) {
+            return luaL_error(L, "failed to unset env var");
+        }
+    } else if (lua_type(L, 3) == LUA_TSTRING) {
+        if (SetEnvironmentVariable(key, lua_tostring(L, 3)) == 0) {
+            return luaL_error(L, "failed to set env var");
+        }
+#else
+    if (lua_isnil(L, 3)) {
+        if (unsetenv(key) != 0) {
+            return luaL_error(L, "failed to unset env var");
+        }
+    } else if (lua_type(L, 3) == LUA_TSTRING) {
+        if (setenv(key, lua_tostring(L, 3), 1) != 0) {
+            return luaL_error(L, "failed to set env var");
+        }
+#endif
+    } else {
+        return luaL_error(L, "env values must be strings or nil");
+    }
+    return 0;
+}
+
+static int env__index(lua_State *L) {
+    const char *key = luaL_checkstring(L, 2);
+    const char *val = getenv(key);
+    if (val)
+        lua_pushstring(L, val);
+    else
+        lua_pushnil(L);
+    return 1;
+}
+
+int luaopen_env(lua_State *L) {
+    lua_newtable(L); // module table
+    lua_newtable(L); // metatable
+    lua_pushcfunction(L, env__index);
+    lua_setfield(L, -2, "__index");
+    lua_pushcfunction(L, env__newindex);
+    lua_setfield(L, -2, "__newindex");
+    lua_setmetatable(L, -2); // setmetatable(t, mt)
+    return 1; // return env table
+}

--- a/nix/nix.lua
+++ b/nix/nix.lua
@@ -1,9 +1,10 @@
 -- lua `stdenv` for runLuaCommand
 return function(shell_hooks)
   _G.sh = require("sh")
-  string.escapeShellArg = getmetatable(sh).repr.posix.escape
-  sh.assert_zero = true
-  sh.stdenv_shell_hooks_path = shell_hooks
+  local sh_settings = getmetatable(sh)
+  string.escapeShellArg = sh_settings.repr.posix.escape
+  sh_settings.assert_zero = true
+  sh_settings.stdenv_shell_hooks_path = shell_hooks
   local shell = os.getenv("SHELL")
   local function with_shell_hooks(cmd)
     return string.format(
@@ -12,7 +13,7 @@ return function(shell_hooks)
       string.escapeShellArg(". " .. shell_hooks .. "\n" .. cmd)
     )
   end
-  sh.transforms = { with_shell_hooks }
+  sh_settings.repr.posix.transforms = { with_shell_hooks }
   function os.write_file(opts, filename, content)
     local file = assert(io.open(filename, opts.append and "a" or "w"))
     file:write(content .. (opts.newline ~= false and "\n" or ""))
@@ -54,12 +55,12 @@ return function(shell_hooks)
       end
     end
     sh.rm("-rf", temp)
-    sh.transforms = {}
+    sh_settings.repr.posix.transforms = {}
     os.remove(shell_hooks)
     assert(ok, tostring(err))
   else
     sh.rm("-rf", temp)
-    sh.transforms = {}
+    sh_settings.repr.posix.transforms = {}
     os.remove(shell_hooks)
     error(tostring(err))
   end


### PR DESCRIPTION
meta is added to each individual command result's actual metatable

meta_main IS the metatable for the current copy of the sh variable (careful! copy can restore the essential values though!)

moved sh.transforms to be a repr specific option i.e. sh.repr = { newshell = { transforms = {} } }

allowed __newindex access on main variable to deepextend if prefixed with _x_ like sh._x_repr = { newshell = { transforms = {} } }

added os.env, equivalent to vim.env, to runLuaCommand.nix